### PR TITLE
Make sure to include the submodules in the git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ImGui.SetNextWindowPos(new ImVec2(10, 10), ImEnum.Cond.Once);
 1. Clone the repository
 
 ```bash
-git clone https://github.com/mori2003/jsimgui.git
+git clone https://github.com/mori2003/jsimgui.git --recurse-submodules
 cd jsimgui
 ```
 


### PR DESCRIPTION
Add the `--recurse-submodules` flag to the `git clone` command to make sure that the submodules are fetched when cloning the repository.